### PR TITLE
More opaque navbar for visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -54,7 +54,7 @@ p {
 
 #navbar {
   /*overflow: hidden;*/
-  background-color: #f1f1f139;
+  background-color: #f1f1f1bb;
   backdrop-filter: blur(2px);
   padding: 50px 10px; /* Large padding which will shrink on scroll (using JS) */
   transition: 0.4s; /* Adds a transition effect when the padding is decreased */
@@ -127,7 +127,7 @@ p {
 .dropdown-content {
   display: none;
   position: absolute;
-  /*background-color: #f1f1f100;*/
+  background-color: #f1f1f1;
   min-width: 160px;
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.273);
   z-index: 1;


### PR DESCRIPTION
Going through the site, I noticed sometimes (on a dark background) it was hard to see the content on the navbar or the dropdown options.  Tried one thing out to see if it helped, see what you think!

### BEFORE
<img width="777" alt="Screen Shot 2022-11-09 at 4 59 02 PM" src="https://user-images.githubusercontent.com/5332944/200975723-e74a783c-335a-47ed-9e60-1b502e6ecb3e.png">
<img width="488" alt="Screen Shot 2022-11-09 at 5 10 25 PM" src="https://user-images.githubusercontent.com/5332944/200975823-8b1de352-daf6-4319-a982-821cc39300b5.png">


### AFTER
<img width="668" alt="Screen Shot 2022-11-09 at 5 06 45 PM" src="https://user-images.githubusercontent.com/5332944/200975787-bf5ab23e-41ab-4163-8f21-ad1c5f57b1d2.png">

